### PR TITLE
Delete buildings having no ID_RSU from the RF analysis

### DIFF
--- a/geoindicators/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/GenericIndicators.groovy
+++ b/geoindicators/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/geoindicators/GenericIndicators.groovy
@@ -831,7 +831,7 @@ IProcess gatherScales() {
                 def idbuildForMerge
                 def idBlockForMerge
 
-                // Calculate average and variance at RSU scale from each indicator of the building scale
+                // Add operations to compute at RSU scale to each indicator of the building scale
                 def inputVarAndOperationsBuild = [:]
                 def buildIndicators = datasource.getTable(buildingTable).getColumns()
                 for (col in buildIndicators) {

--- a/osm/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/osm/WorkflowOSM.groovy
+++ b/osm/src/main/groovy/org/orbisgis/orbisprocess/geoclimate/osm/WorkflowOSM.groovy
@@ -342,6 +342,7 @@ IProcess osm_processing() {
         outputs outputMessage: String
         run { h2gis_datasource, processing_parameters, id_zones, outputFolder, ouputTableFiles, output_datasource, outputTableNames, outputSRID ->
 
+            // Temporary tables
             int nbAreas = id_zones.size();
             info "$nbAreas osm areas will be processed"
             def geoIndicatorsComputed = false
@@ -454,12 +455,17 @@ IProcess osm_processing() {
                                         def buildingIndicatorsTableName = results.outputTableBuildingIndicators;
                                         h2gis_datasource.getTable(buildingEstimateTableName).id_build.createIndex()
                                         h2gis_datasource.getTable(buildingIndicatorsTableName).id_build.createIndex()
+                                        h2gis_datasource.getTable(buildingIndicatorsTableName).id_rsu.createIndex()
 
                                         def buildingEstimateWithIndicators = "ESTIMATED_BUILDING_INDICATORS_${UUID.randomUUID().toString().replaceAll("-", "_")}"
 
                                         h2gis_datasource.execute """DROP TABLE IF EXISTS $buildingEstimateWithIndicators;
-                                           CREATE TABLE $buildingEstimateWithIndicators as SELECT a.* from $buildingIndicatorsTableName 
-                                            a left join $buildingEstimateTableName b on a.id_build=b.id_build where b.ESTIMATED = true;"""
+                                           CREATE TABLE $buildingEstimateWithIndicators 
+                                                    AS SELECT a.*
+                                                    FROM $buildingIndicatorsTableName a 
+                                                        LEFT JOIN $buildingEstimateTableName b 
+                                                        ON a.id_build=b.id_build
+                                                    WHERE b.ESTIMATED = true AND a.ID_RSU IS NOT NULL;"""
 
                                         info "Collect building indicators to estimate the height for the ${id_zone}"
 

--- a/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/ProcessingChainOSMTest.groovy
+++ b/osm/src/test/groovy/org/orbisgis/orbisprocess/geoclimate/osm/ProcessingChainOSMTest.groovy
@@ -506,10 +506,10 @@ class ProcessingChainOSMTest extends ChainProcessAbstractTest {
                 "description" :"Example of configuration file to run the OSM workflow and store the resultst in a folder",
                 "geoclimatedb" : [
                         "path" : "${dirFile.absolutePath+File.separator+"geoclimate_chain_db;AUTO_SERVER=TRUE"}",
-                        "delete" :true
+                        "delete" :false
                 ],
                 "input" : [
-                        "osm" : ["pont de veyle "]],
+                        "osm" : ["pont-de-veyle "]],
                 "output" :[
                         "folder" : "$directory"],
                 "parameters":


### PR DESCRIPTION
Actually only remove rows having no ID_RSU from the RF. No need to make a omitNullRows. Remains a problem due to the fact that applyRF was initially thought to work only for classification problem:
>[INFO] org.orbisgis.orbisdata.processmanager.process.GroovyProcessFactory - Apply a Random Forest model
    Security framework of XStream not initialized, XStream is probably vulnerable.
    [ERROR] org.orbisgis.orbisdata.processmanager.process.Process - Error while executing the process.
    groovy.lang.MissingMethodException: No signature of method: [Lsmile.regression.RegressionTree;.get() is applicable for argument types: (Integer) values: [0]
